### PR TITLE
Use StyledYaml so we can always double quote the sha.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,11 +7,13 @@ gem "commander"
 
 gem "activesupport"
 gem "pry-byebug"
+gem 'styled_yaml', '~> 0.0.1'
+
 # Add dependencies to develop your gem here.
 # Include everything needed to run rake, tests, features, etc.
 group :development do
   gem "rdoc", "~> 3.12"
-  gem "bundler", "~> 1.0"
+  gem "bundler", "~> 2.3"
   gem "juwelier", "~> 2.4.9", git: "https://github.com/flajann2/juwelier"
   gem "simplecov", ">= 0"
   gem "test-unit", ">= 0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,6 +106,7 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
+    styled_yaml (0.0.1)
     test-unit (3.2.9)
       power_assert
     thread_safe (0.3.6)
@@ -117,12 +118,13 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport
-  bundler (~> 1.0)
+  bundler (~> 2.3)
   commander
   juwelier (~> 2.4.9)!
   pry-byebug
   rdoc (~> 3.12)
   simplecov
+  styled_yaml (~> 0.0.1)
   test-unit
 
 BUNDLED WITH

--- a/lib/pfab/cli.rb
+++ b/lib/pfab/cli.rb
@@ -3,6 +3,7 @@ require "net/http"
 require "yaml"
 require "json"
 require 'active_support/core_ext/hash/indifferent_access'
+require 'styled_yaml'
 
 module Pfab
   class CLI

--- a/lib/pfab/templates/cron.rb
+++ b/lib/pfab/templates/cron.rb
@@ -2,7 +2,7 @@ module Pfab
   module Templates
     class Cron < Base
       def write_to(f)
-        f << YAML.dump(job.deep_stringify_keys)
+        f << StyledYAML.dump(job.deep_stringify_keys)
       end
 
       def application_type
@@ -23,7 +23,7 @@ module Pfab
               "deploy-id" => deploy_id,
               "tags.datadoghq.com/env": @data['env'],
               "tags.datadoghq.com/service": @data['deployed_name'],
-              "tags.datadoghq.com/version": "#{@data['sha']}"
+              "tags.datadoghq.com/version": StyledYAML.double_quoted(@data['sha'])
             }
           },
           spec: {
@@ -49,7 +49,7 @@ module Pfab
                       "application-type" => "cron",
                       "tags.datadoghq.com/env": @data['env'],
                       "tags.datadoghq.com/service": @data['deployed_name'],
-                      "tags.datadoghq.com/version": "#{@data['sha']}"
+                      "tags.datadoghq.com/version": StyledYAML.double_quoted(@data['sha'])
                     },
                   },
                   spec: {

--- a/lib/pfab/templates/daemon.rb
+++ b/lib/pfab/templates/daemon.rb
@@ -2,7 +2,7 @@ module Pfab
   module Templates
     class Daemon < Base
       def write_to(f)
-        f << YAML.dump(deployment.deep_stringify_keys)
+        f << StyledYAML.dump(deployment.deep_stringify_keys)
       end
 
       def application_type
@@ -23,7 +23,7 @@ module Pfab
               "deploy-id" => deploy_id,
               "tags.datadoghq.com/env": @data['env'],
               "tags.datadoghq.com/service": @data['deployed_name'],
-              "tags.datadoghq.com/version":"#{@data['sha']}"
+              "tags.datadoghq.com/version": StyledYAML.double_quoted(@data['sha'])
             }
           },
           spec: {
@@ -45,7 +45,7 @@ module Pfab
                   "application-type" => "daemon",
                   "tags.datadoghq.com/env": @data['env'],
                   "tags.datadoghq.com/service": @data['deployed_name'],
-                  "tags.datadoghq.com/version": "#{@data['sha']}"
+                  "tags.datadoghq.com/version": StyledYAML.double_quoted(@data['sha'])
                 },
               },
               spec: {

--- a/lib/pfab/templates/job.rb
+++ b/lib/pfab/templates/job.rb
@@ -2,7 +2,7 @@ module Pfab
   module Templates
     class Job < Base
       def write_to(f)
-        f << YAML.dump(job.deep_stringify_keys)
+        f << StyledYAML.dump(job.deep_stringify_keys)
       end
 
       def application_type
@@ -23,7 +23,7 @@ module Pfab
               "deploy-id" => deploy_id,
               "tags.datadoghq.com/env": @data['env'],
               "tags.datadoghq.com/service": @data['deployed_name'],
-              "tags.datadoghq.com/version":"#{@data['sha']}"
+              "tags.datadoghq.com/version": StyledYAML.double_quoted(@data['sha'])
             }
           },
           spec: {
@@ -40,7 +40,7 @@ module Pfab
                   "application-type" => "job",
                   "tags.datadoghq.com/env": @data['env'],
                   "tags.datadoghq.com/service": @data['deployed_name'],
-                  "tags.datadoghq.com/version": "#{@data['sha']}"
+                  "tags.datadoghq.com/version": StyledYAML.double_quoted(@data['sha'])
                 },
               },
               spec: {

--- a/lib/pfab/templates/web.rb
+++ b/lib/pfab/templates/web.rb
@@ -1,3 +1,5 @@
+require "rubygems/safe_yaml"
+
 module Pfab
   module Templates
     class Web < Base
@@ -5,13 +7,13 @@ module Pfab
         if get("host").nil?
           puts "No host to deploy to for #{@data['deployed_name']}. Skipping."
         else
-          f << YAML.dump(service.deep_stringify_keys)
+          f << StyledYAML.dump(service.deep_stringify_keys)
           if not app_vars.has_key?('generateIngressEnabled') || app_vars['generateIngressEnabled']
-            f << YAML.dump(ingress.deep_stringify_keys)
+            f << StyledYAML.dump(ingress.deep_stringify_keys)
           else
             puts "skipping ingress because ingress_disabled = #{@data['generateIngressEnabled']}"
           end
-          f << YAML.dump(deployment.deep_stringify_keys)
+          f << StyledYAML.dump(deployment.deep_stringify_keys)
         end
       end
 
@@ -198,7 +200,7 @@ module Pfab
               "deploy-id" => deploy_id,
               "tags.datadoghq.com/env": @data['env'],
               "tags.datadoghq.com/service": @data['deployed_name'],
-              "tags.datadoghq.com/version":"#{@data['sha']}"
+              "tags.datadoghq.com/version": StyledYAML.double_quoted(@data['sha'])
             }
           },
           spec: {
@@ -225,7 +227,7 @@ module Pfab
                   "application-type" => "web",
                   "tags.datadoghq.com/env": @data['env'],
                   "tags.datadoghq.com/service": @data['deployed_name'],
-                  "tags.datadoghq.com/version": "#{@data['sha']}"
+                  "tags.datadoghq.com/version": StyledYAML.double_quoted(@data['sha'])
                 },
               },
               spec: {


### PR DESCRIPTION
Without doing this, kube can get confused and try to handle it as a number and emit an error like this: `error: unable to decode ".application-k8s-staging-prefab-api-web-api.yaml": json: cannot unmarshal number into Go struct field ObjectMeta.metadata.labels of type string`