### PR TITLE
Tweaks

### DIFF
--- a/lib/pfab/cli.rb
+++ b/lib/pfab/cli.rb
@@ -85,6 +85,8 @@ module Pfab
           if success
             cmd_generate_yaml
             cmd_apply(timeout: options.timeout, retries: options.retries, sleep_duration: options.sleep, tagged: options.tagged)
+          else
+            raise "Build failed"
           end
         end
       end

--- a/lib/pfab/cli.rb
+++ b/lib/pfab/cli.rb
@@ -474,9 +474,10 @@ module Pfab
 
     def get_app_name(all: false, include_run_locals: false)
       return $app_name unless $app_name.nil?
-      apps = deployables.keys
-      apps.concat(run_locals.keys) if include_run_locals
+      apps = []
       apps << "all" if all
+      apps.concat(deployables.keys)
+      apps.concat(run_locals.keys) if include_run_locals
       $app_name = choose("which app?", *apps)
     end
 

--- a/lib/pfab/templates/web.rb
+++ b/lib/pfab/templates/web.rb
@@ -303,14 +303,14 @@ module Pfab
             name: @data['deployed_name'],
             namespace: get_namespace,
             labels: {
-              application: @data['application'],
+              "application" => @data['application'],
               "deployed-name" => @data['deployed_name'],
               "application-type" => application_type,
               "deploy-id" => deploy_id,
-              LABEL_DEPLOY_UNIQUE_ID: StyledYAML.double_quoted(deploy_unique_id),
-              "tags.datadoghq.com/env": @data['env'],
-              "tags.datadoghq.com/service": @data['deployed_name'],
-              "tags.datadoghq.com/version": StyledYAML.double_quoted(@data['sha'])
+              LABEL_DEPLOY_UNIQUE_ID => StyledYAML.double_quoted(deploy_unique_id),
+              "tags.datadoghq.com/env" => @data['env'],
+              "tags.datadoghq.com/service" => @data['deployed_name'],
+              "tags.datadoghq.com/version" => StyledYAML.double_quoted(@data['sha'])
             }
           },
           spec: {

--- a/lib/pfab/templates/web.rb
+++ b/lib/pfab/templates/web.rb
@@ -171,21 +171,6 @@ module Pfab
         }
         return pdb
       end
-      ANTI_AFFINITY_TYPES = %w[disabled required preferred]
-      ANTI_AFFINITY_MODE = 'antiAffinityMode'
-      ANTI_AFFINITY_PREFERRED_MODE_WEIGHT = 'antiAffinityPreferredModeWeight'
-      ZONE_ANTI_AFFINITY_MODE = 'zoneAntiAffinityMode'
-      ZONE_ANTI_AFFINITY_PREFERRED_MODE_WEIGHT = 'zoneAntiAffinityPreferredModeWeight'
-
-
-      def anti_affinity
-        return host_anti_affinity
-      end
-
-
-      def host_anti_affinity
-        anti_affinity_builder(ANTI_AFFINITY_MODE, ANTI_AFFINITY_PREFERRED_MODE_WEIGHT, "kubernetes.io/hostname")
-      end
 
 
       def topology_spread_constraints
@@ -232,40 +217,6 @@ module Pfab
         }
       end
 
-      def anti_affinity_builder(key, weight_key, topology_key)
-        antiAffinityMode = get(key) || "disabled"
-        if antiAffinityMode
-          affinitySelector = {
-            topologyKey: topology_key,
-            labelSelector: labelSelector,
-          }
-
-          return case antiAffinityMode
-                 when "disabled"
-                   puts "antiAffinityMode is set to disabled, skipping"
-                   {}
-                 when "required"
-                   {
-                     podAntiAffinity: {
-                       requiredDuringSchedulingIgnoredDuringExecution: [
-                         affinitySelector
-                       ] } }
-                 when "preferred"
-                   { podAntiAffinity: {
-                     preferredDuringSchedulingIgnoredDuringExecution: [
-                       {
-                         weight: app_vars[weight_key] || 100,
-                         podAffinityTerm: affinitySelector
-                       }
-                     ]
-                   }
-                   }
-                 else
-                   raise "Unexpected value #{antiAffinityMode} specified for `#{key}`. Valid selections are #{ANTI_AFFINITY_TYPES}"
-                 end
-        end
-        return {}
-      end
 
       def deployment
         secret_mounts = get("secretMounts") || []

--- a/lib/pfab/templates/web.rb
+++ b/lib/pfab/templates/web.rb
@@ -15,7 +15,8 @@ module Pfab
             puts "skipping ingress because ingress_disabled = #{@data['generateIngressEnabled']}"
           end
           f << StyledYAML.dump(deployment.deep_stringify_keys)
-          replica_count = get("replicas") ||1
+          raw_replicas = get("replicas")
+          replica_count = raw_replicas ? raw_replicas.to_i : 1
           if (replica_count > 1)
             f << StyledYAML.dump(pod_disruption_budget.deep_stringify_keys)
           end


### PR DESCRIPTION
- made the "all" option always be first on the list so it doesn't move as more deploy items are added
- ensured that replica count comparisons were always happening in integer land
- make topology constraints only happen when replica count > 1 like pod disruption budgets
- removed some old code 